### PR TITLE
Bump Akka version to 2.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licen
 homepage := Some(new URL("https://github.com/NewMotion/akka-rabbitmq"))
 
 def akka(scalaVersion: String) = {
-  val version = "2.4.14"
+  val version = "2.5.7"
 
   def libs(xs: String*) = xs.map(x => "com.typesafe.akka" %% s"akka-$x" % version)
 

--- a/src/test/scala/akka/rabbitmq/StashUntilChannelSpec.scala
+++ b/src/test/scala/akka/rabbitmq/StashUntilChannelSpec.scala
@@ -12,7 +12,7 @@ class StashUntilChannelSpec extends ActorSpec {
 
     "handle ChannelCreated message and switch context" in new TestScope {
       actor ! Command
-      expectNoMsg()
+      expectNoMessage(remainingOrDefault)
       actor ! ChannelCreated(testActor)
       actor ! Command
       expectMsg(Reply(testActor))


### PR DESCRIPTION
I was getting some evictions errors as I was using latest version (2.5.7). I also updated a method on one of the tests to avoid a deprecation warning.