### PR TITLE
Add comments header at start of reference.conf.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,3 +1,8 @@
+#######################################
+# akka-rabbitmq Reference Config File #
+#######################################
+
+
 akka-rabbitmq {
   default-connection-dispatcher {
     type = "Dispatcher"


### PR DESCRIPTION
Without these comments, merging akka-http's `reference.conf` with this one, results in a syntax error:

```
[...]
  # server-sent events
  sse {
    # The maximum size for parsing server-sent events.
    max-event-size = 8192

    # The maximum size for parsing lines of a server-sent event.
    max-line-size = 4096
  }
}akka-rabbitmq { # MISSING NEW-LINE on akka-http's reference.conf
  default-connection-dispatcher {
    type = "Dispatcher"
    executor = "fork-join-executor"
[...]
```

See https://github.com/akka/akka-http/pull/2841