### PR TITLE
Remove 2.11 build from travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 scala:
   - 2.13.0
   - 2.12.8
-  - 2.11.12
 jdk:
   - oraclejdk8
 sudo: false


### PR DESCRIPTION
We noticed that the latest pull request was failing build possibly due to 2.11 still being in the travis CI file. This pull request removes it which should hopefully then allow https://github.com/NewMotion/akka-rabbitmq/pull/64 to be merged successfully.